### PR TITLE
Make setAvatarViewSize: public

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -151,6 +151,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (weak, nonatomic, readonly, nullable) UIImageView *avatarImageView;
 
+- (void)setAvatarViewSize:(CGSize)avatarViewSize;
+
 /**
  *  Returns the avatar container view of the cell. This view is the superview of the cell's avatarImageView.
  *


### PR DESCRIPTION
This way to make sure we can reuse the avatar image view to show message delivery failed icon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/loongman/jsqmessagesviewcontroller/1)
<!-- Reviewable:end -->
